### PR TITLE
feat: 로그인 및 마이페이지 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@tanstack/react-query": "^5.53.3",
         "@tanstack/react-query-devtools": "^5.54.0",
+        "axios": "^1.7.7",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-router-dom": "^6.26.1",
@@ -2968,6 +2969,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
     "node_modules/autoprefixer": {
       "version": "10.4.20",
       "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.20.tgz",
@@ -3004,6 +3011,17 @@
       },
       "peerDependencies": {
         "postcss": "^8.1.0"
+      }
+    },
+    "node_modules/axios": {
+      "version": "1.7.7",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.7.tgz",
+      "integrity": "sha512-S4kL7XrjgBmvdGut0sN3yJxqYzrDOnivkBiN0OFs6hLiUam3UPvswUo0kqGyhqUZGEOytHyumEdXsAkgCOUf3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
       }
     },
     "node_modules/babel-jest": {
@@ -3568,6 +3586,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/commander": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
@@ -3773,6 +3803,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/detect-newline": {
@@ -4433,6 +4472,26 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/follow-redirects": {
+      "version": "1.15.9",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
+      "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/foreground-child": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.0.tgz",
@@ -4448,6 +4507,20 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/fraction.js": {
@@ -7066,6 +7139,27 @@
         "node": ">=8.6"
       }
     },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/mimic-fn": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
@@ -7720,6 +7814,12 @@
       "engines": {
         "node": ">= 6"
       }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "license": "MIT"
     },
     "node_modules/punycode": {
       "version": "2.3.1",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "@tanstack/react-query": "^5.53.3",
     "@tanstack/react-query-devtools": "^5.54.0",
+    "axios": "^1.7.7",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-router-dom": "^6.26.1",

--- a/src/apis/apis.config.ts
+++ b/src/apis/apis.config.ts
@@ -1,0 +1,9 @@
+import axios from "axios";
+
+const createAPI = (baseURL: string) => {
+  return axios.create({
+    baseURL: baseURL,
+  });
+};
+
+export { createAPI };

--- a/src/apis/auth/auth.api.ts
+++ b/src/apis/auth/auth.api.ts
@@ -1,0 +1,36 @@
+import { loginProps, signUpProps } from "@/types/Auth";
+import axiosInstance from "./axiosInstance";
+
+const ACCESS_TOKEN_EXPIRY_TIME = "15m";
+
+const login = async ({ id, password }: loginProps) => {
+  const response = await axiosInstance.post(
+    `/login?expiresIn=${ACCESS_TOKEN_EXPIRY_TIME}`,
+    {
+      id,
+      password,
+    }
+  );
+
+  if (response.data.success) {
+    localStorage.setItem("acToken", response.data.accessToken);
+  }
+
+  return response.data;
+};
+
+const logout = () => {
+  localStorage.removeItem("acToken");
+};
+
+const signUp = async ({ id, password, nickname }: signUpProps) => {
+  const response = await axiosInstance.post("/register", {
+    id,
+    password,
+    nickname,
+  });
+
+  return response.data;
+};
+
+export { login, logout, signUp };

--- a/src/apis/auth/auth.api.ts
+++ b/src/apis/auth/auth.api.ts
@@ -1,7 +1,7 @@
 import { loginProps, signUpProps } from "@/types/Auth";
 import axiosInstance from "./axiosInstance";
 
-const ACCESS_TOKEN_EXPIRY_TIME = "15m";
+const ACCESS_TOKEN_EXPIRY_TIME = "30m";
 
 const login = async ({ id, password }: loginProps) => {
   const response = await axiosInstance.post(

--- a/src/apis/auth/auth.api.ts
+++ b/src/apis/auth/auth.api.ts
@@ -21,6 +21,7 @@ const login = async ({ id, password }: loginProps) => {
 
 const logout = () => {
   localStorage.removeItem("acToken");
+  alert("로그아웃 되었습니다.");
 };
 
 const signUp = async ({ id, password, nickname }: signUpProps) => {

--- a/src/apis/auth/axiosInstance.ts
+++ b/src/apis/auth/axiosInstance.ts
@@ -1,0 +1,15 @@
+import { createAPI } from "../apis.config";
+
+const axiosInstance = createAPI(import.meta.env.VITE_AUTH_BASE_URL);
+
+axiosInstance.interceptors.request.use((axiosConfig) => {
+  const accessToken = localStorage.getItem("acToken");
+
+  if (accessToken) {
+    axiosConfig.headers.Authorization = `Bearer ${accessToken}`;
+  }
+
+  return axiosConfig;
+});
+
+export default axiosInstance;

--- a/src/apis/auth/user.api.ts
+++ b/src/apis/auth/user.api.ts
@@ -1,3 +1,4 @@
+import { UserProfileResponse } from "@/types/User";
 import axiosInstance from "./axiosInstance";
 
 const getUserInfo = async () => {
@@ -10,4 +11,26 @@ const getUserInfo = async () => {
   return response.data;
 };
 
-export { getUserInfo };
+const updateProfile = async (
+  formData: FormData
+): Promise<UserProfileResponse> => {
+  try {
+    const response = await axiosInstance.patch<UserProfileResponse>(
+      "/profile",
+      formData,
+      {
+        headers: {
+          Authorization: `Bearer ${localStorage.getItem("acToken")}`,
+          "Content-Type": "multipart/form-data",
+        },
+      }
+    );
+    return response.data;
+  } catch (error) {
+    throw new Error(
+      `프로필 업데이트 중 문제가 발생했습니다. 다시 시도해주세요: ${error}`
+    );
+  }
+};
+
+export { getUserInfo, updateProfile };

--- a/src/apis/auth/user.api.ts
+++ b/src/apis/auth/user.api.ts
@@ -1,0 +1,13 @@
+import axiosInstance from "./axiosInstance";
+
+const getUserInfo = async () => {
+  const response = await axiosInstance.get("/user", {
+    headers: {
+      Authorization: `Bearer ${localStorage.getItem("acToken")}`,
+    },
+  });
+
+  return response.data;
+};
+
+export { getUserInfo };

--- a/src/apis/shoes.api.ts
+++ b/src/apis/shoes.api.ts
@@ -1,0 +1,10 @@
+import { createAPI } from "./apis.config";
+
+const shoesAPI = createAPI(import.meta.env.VITE_SHOES_BASE_URL);
+
+const fetchShoesLists = async () => {
+  const response = await shoesAPI.get("/");
+  return response.data;
+};
+
+export { fetchShoesLists };

--- a/src/assets/avatar-gray.svg
+++ b/src/assets/avatar-gray.svg
@@ -1,0 +1,12 @@
+<svg width="61" height="60" viewBox="0 0 61 60" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g clip-path="url(#clip0_167_5751)">
+<circle cx="30.9102" cy="30" r="29" fill="#EFEFF0" stroke="#AFB1B6" stroke-width="2"/>
+<circle cx="30.9102" cy="23.75" r="10.25" stroke="#AFB1B6" stroke-width="2"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M7.18945 48.3694C12.3708 41.8053 21.0621 37.5 30.9097 37.5C40.7573 37.5 49.4486 41.8053 54.6299 48.3694C54.2095 48.9115 53.7709 49.4388 53.3151 49.9504C48.5855 43.7106 40.4142 39.5 30.9097 39.5C21.4052 39.5 13.2339 43.7106 8.50434 49.9504C8.04848 49.4388 7.60988 48.9115 7.18945 48.3694Z" fill="#AFB1B6"/>
+</g>
+<defs>
+<clipPath id="clip0_167_5751">
+<rect width="60" height="60" fill="white" transform="translate(0.910156)"/>
+</clipPath>
+</defs>
+</svg>

--- a/src/components/Commons/Input/Input.tsx
+++ b/src/components/Commons/Input/Input.tsx
@@ -1,0 +1,50 @@
+import {
+  ForwardedRef,
+  forwardRef,
+  InputHTMLAttributes,
+  ReactNode,
+  useId,
+} from "react";
+
+interface InputProps extends InputHTMLAttributes<HTMLInputElement> {
+  label?: string;
+  errorMessage?: string;
+  checkIdButton?: ReactNode;
+}
+
+function Input(
+  { label, errorMessage, checkIdButton, ...inputProps }: InputProps,
+  ref: ForwardedRef<HTMLInputElement>
+) {
+  const uniqueId = useId();
+
+  return (
+    <div className="flex flex-col">
+      <label
+        htmlFor={uniqueId}
+        className="block mb-4 font-semibold text-slate-700"
+      >
+        {label}
+      </label>
+
+      <input
+        id={uniqueId}
+        ref={ref}
+        {...inputProps}
+        className={`w-full px-3 py-2 border outline-none ${
+          errorMessage ? "border-red-500" : "border-gray-300"
+        } rounded-md shadow-sm focus:border-1 focus:border-blue-500`}
+      />
+      {checkIdButton && (
+        <div className="absolute right-4 top-1/2 -translate-y-1/2">
+          {checkIdButton}
+        </div>
+      )}
+      {errorMessage && (
+        <p className="mt-1 text-sm text-red-500">{errorMessage}</p>
+      )}
+    </div>
+  );
+}
+
+export default forwardRef(Input);

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -1,5 +1,10 @@
 function Header() {
-  return <></>;
+  return (
+    <header className="common-layout flex justify-between items-center w-full h-[52px]">
+      <h2>logo</h2>
+      <button>로그인</button>
+    </header>
+  );
 }
 
 export default Header;

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -1,8 +1,39 @@
+import { logout } from "@/apis/auth/auth.api";
+import { HEADER_HEIGHT } from "@/constants/Layout";
+import { useIsLoggedIn } from "@/hooks/useUser";
+import { useNavigate } from "react-router-dom";
+
 function Header() {
+  const navigate = useNavigate();
+  const isLoggedIn = useIsLoggedIn();
+  // const { data: userData } = useUserInfos(isLoggedIn);
+
+  const handleMoveHomePage = () => {
+    navigate("/");
+  };
+
+  const handleLogin = () => {
+    navigate("/login");
+  };
+
+  const handleLogout = () => {
+    logout();
+    navigate("/");
+  };
+
   return (
-    <header className="common-layout flex justify-between items-center w-full h-[52px]">
-      <h2>logo</h2>
-      <button>로그인</button>
+    <header
+      className={`common-layout flex justify-between items-center w-full h-${HEADER_HEIGHT}`}
+      role="banner"
+    >
+      <h2 className="cursor-pointer" onClick={handleMoveHomePage}>
+        logo
+      </h2>
+      {!isLoggedIn ? (
+        <button onClick={handleLogin}>로그인</button>
+      ) : (
+        <button onClick={handleLogout}>로그아웃</button>
+      )}
     </header>
   );
 }

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -6,7 +6,7 @@ import { useNavigate } from "react-router-dom";
 function Header() {
   const navigate = useNavigate();
   const isLoggedIn = useIsLoggedIn();
-  // const { data: userData } = useUserInfos(isLoggedIn);
+  // const { data: userData } = useUserInfos();
 
   const handleMoveHomePage = () => {
     navigate("/");
@@ -21,6 +21,10 @@ function Header() {
     navigate("/");
   };
 
+  const handleMoveMyPage = () => {
+    navigate("/my-page");
+  };
+
   return (
     <header
       className={`common-layout flex justify-between items-center w-full h-${HEADER_HEIGHT}`}
@@ -32,7 +36,10 @@ function Header() {
       {!isLoggedIn ? (
         <button onClick={handleLogin}>로그인</button>
       ) : (
-        <button onClick={handleLogout}>로그아웃</button>
+        <div className="flex gap-4">
+          <button onClick={handleMoveMyPage}>마이 페이지</button>
+          <button onClick={handleLogout}>로그아웃</button>
+        </div>
       )}
     </header>
   );

--- a/src/components/Layouts/Layout.tsx
+++ b/src/components/Layouts/Layout.tsx
@@ -1,10 +1,14 @@
 import { Outlet } from "react-router-dom";
+import Header from "../Header/Header";
 
 function Layout() {
   return (
-    <main>
-      <Outlet />
-    </main>
+    <>
+      <Header />
+      <main className="common-layout">
+        <Outlet />
+      </main>
+    </>
   );
 }
 

--- a/src/components/Layouts/Layout.tsx
+++ b/src/components/Layouts/Layout.tsx
@@ -3,12 +3,12 @@ import Header from "../Header/Header";
 
 function Layout() {
   return (
-    <>
+    <div className="max-w-[1024px] w-full h-screen mx-auto">
       <Header />
-      <main className="common-layout">
+      <main role="main">
         <Outlet />
       </main>
-    </>
+    </div>
   );
 }
 

--- a/src/constants/Layout.ts
+++ b/src/constants/Layout.ts
@@ -1,0 +1,1 @@
+export const HEADER_HEIGHT = "[52px]"; // header 높이

--- a/src/constants/queryKeys.ts
+++ b/src/constants/queryKeys.ts
@@ -4,4 +4,5 @@ export const shoesKeys = {
 
 export const userKeys = {
   user: ["user"] as const,
+  userinfos: ["userInfos"] as const,
 };

--- a/src/constants/queryKeys.ts
+++ b/src/constants/queryKeys.ts
@@ -1,0 +1,7 @@
+export const shoesKeys = {
+  all: ["shoes"] as const,
+};
+
+export const userKeys = {
+  user: ["user"] as const,
+};

--- a/src/hooks/useShoes.ts
+++ b/src/hooks/useShoes.ts
@@ -1,0 +1,16 @@
+import { useQuery } from "@tanstack/react-query";
+import { fetchShoesLists } from "../apis/shoes.api";
+import { shoesKeys } from "../constants/queryKeys";
+import { Shoes } from "../types/Shoes";
+
+const useShoesList = () => {
+  return useQuery<Shoes[]>({
+    queryKey: shoesKeys.all,
+    queryFn: fetchShoesLists,
+    staleTime: 1000 * 60 * 5,
+    gcTime: 1000 * 60 * 10,
+    refetchOnWindowFocus: false,
+  });
+};
+
+export { useShoesList };

--- a/src/hooks/useShoes.ts
+++ b/src/hooks/useShoes.ts
@@ -1,7 +1,7 @@
+import { fetchShoesLists } from "@/apis/shoes.api";
+import { shoesKeys } from "@/constants/queryKeys";
+import { Shoes } from "@/types/Shoes";
 import { useQuery } from "@tanstack/react-query";
-import { fetchShoesLists } from "../apis/shoes.api";
-import { shoesKeys } from "../constants/queryKeys";
-import { Shoes } from "../types/Shoes";
 
 const useShoesList = () => {
   return useQuery<Shoes[]>({

--- a/src/hooks/useUser.ts
+++ b/src/hooks/useUser.ts
@@ -1,8 +1,12 @@
-import { getUserInfo } from "@/apis/auth/user.api";
+import { getUserInfo, updateProfile } from "@/apis/auth/user.api";
 import { userKeys } from "@/constants/queryKeys";
-import { useQuery } from "@tanstack/react-query";
+import { UpdateProfileType, UserProfileResponse } from "@/types/User";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { AxiosError } from "axios";
 
-const useUserInfos = (isLoggedIn: boolean) => {
+const useUserInfos = () => {
+  const isLoggedIn = useIsLoggedIn();
+
   return useQuery({
     queryKey: userKeys.user,
     queryFn: getUserInfo,
@@ -17,4 +21,33 @@ const useIsLoggedIn = () => {
   return !!token;
 };
 
-export { useIsLoggedIn, useUserInfos };
+const useUpdateProfile = (): UpdateProfileType => {
+  const queryClient = useQueryClient();
+  const { refetch } = useUserInfos();
+
+  const { mutate, isPending, isError, error } = useMutation({
+    mutationFn: updateProfile,
+    onSuccess: (data) => {
+      const profileData = data as UserProfileResponse;
+      console.log("프로필 업데이트 성공", profileData);
+
+      queryClient.invalidateQueries({ queryKey: userKeys.userinfos });
+      refetch();
+
+      alert("프로필이 성공적으로 업데이트되었습니다.");
+    },
+    onError: (error: AxiosError) => {
+      console.error("프로필 업데이트 오류", error.response?.data);
+      alert(`프로필 업데이트 중 문제가 발생했습니다: ${error.message}`);
+    },
+  });
+
+  return {
+    mutate: (formData: FormData) => mutate(formData),
+    isPending,
+    isError,
+    error: error ? (error as AxiosError) : null,
+  };
+};
+
+export { useIsLoggedIn, useUpdateProfile, useUserInfos };

--- a/src/hooks/useUser.ts
+++ b/src/hooks/useUser.ts
@@ -2,11 +2,19 @@ import { getUserInfo } from "@/apis/auth/user.api";
 import { userKeys } from "@/constants/queryKeys";
 import { useQuery } from "@tanstack/react-query";
 
-export const useUser = () => {
+const useUserInfos = (isLoggedIn: boolean) => {
   return useQuery({
     queryKey: userKeys.user,
     queryFn: getUserInfo,
     staleTime: 1000 * 60 * 5,
     gcTime: 1000 * 60 * 15,
+    enabled: isLoggedIn,
   });
 };
+
+const useIsLoggedIn = () => {
+  const token = localStorage.getItem("acToken");
+  return !!token;
+};
+
+export { useIsLoggedIn, useUserInfos };

--- a/src/hooks/useUser.ts
+++ b/src/hooks/useUser.ts
@@ -1,0 +1,12 @@
+import { getUserInfo } from "@/apis/auth/user.api";
+import { userKeys } from "@/constants/queryKeys";
+import { useQuery } from "@tanstack/react-query";
+
+export const useUser = () => {
+  return useQuery({
+    queryKey: userKeys.user,
+    queryFn: getUserInfo,
+    staleTime: 1000 * 60 * 5,
+    gcTime: 1000 * 60 * 15,
+  });
+};

--- a/src/hooks/useValidation.ts
+++ b/src/hooks/useValidation.ts
@@ -1,0 +1,51 @@
+import {
+  validateId,
+  validateNickname,
+  validatePassword,
+} from "@/utils/validation";
+import { useState } from "react";
+
+const useValidation = () => {
+  const [errorMessages, setErrorMessages] = useState({
+    idError: "",
+    passwordError: "",
+    nicknameError: "",
+  });
+
+  const validateForm = (id: string, password: string, nickname?: string) => {
+    let isValid = true;
+
+    const newErrors = {
+      idError: "",
+      passwordError: "",
+      nicknameError: "",
+    };
+
+    if (!validateId(id)) {
+      newErrors.idError = "아이디는 4글자 이상이어야 합니다.";
+      isValid = false;
+    }
+
+    if (!validatePassword(password)) {
+      newErrors.passwordError =
+        "비밀번호는 8~20자리이며, 대문자, 숫자, 특수문자를 최소 1개 이상 포함해야 합니다.";
+      isValid = false;
+    }
+
+    if (nickname && !validateNickname(nickname)) {
+      newErrors.nicknameError = "닉네임은 2글자 이상이어야 합니다.";
+      isValid = false;
+    }
+
+    setErrorMessages(newErrors);
+
+    return isValid;
+  };
+
+  return {
+    errors: errorMessages,
+    validateForm,
+  };
+};
+
+export { useValidation };

--- a/src/index.css
+++ b/src/index.css
@@ -1,3 +1,11 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+main {
+  margin: 0 auto;
+}
+
+.common-layout {
+  @apply max-w-[1024px] w-full mx-auto;
+}

--- a/src/index.css
+++ b/src/index.css
@@ -1,11 +1,3 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
-
-main {
-  margin: 0 auto;
-}
-
-.common-layout {
-  @apply max-w-[1024px] w-full mx-auto;
-}

--- a/src/pages/Home/HomePage.tsx
+++ b/src/pages/Home/HomePage.tsx
@@ -5,9 +5,7 @@ function HomePage() {
   const { data: shoes = [], isLoading: isPending, error } = useShoesList();
 
   if (isPending) return <p>Loading...</p>;
-  if (error) return <p>Error loading shoes data</p>;
-
-  console.log(shoes);
+  if (error) return <p>데이터를 불러오는 도중 에러가 발생했어요...*:</p>;
 
   return (
     <>
@@ -16,13 +14,12 @@ function HomePage() {
         {shoes?.length > 0 ? (
           shoes.map((shoe: Shoes) => (
             <div className="shoe-item" key={shoe.id}>
-              {/* 이미지 대신 title과 completed 상태를 출력 */}
               <h3>{shoe.title}</h3>
               <p>{shoe.completed ? "Completed" : "Not Completed"}</p>
             </div>
           ))
         ) : (
-          <p>No shoes available</p>
+          <p>데이터가 없어요...</p>
         )}
       </div>
     </>

--- a/src/pages/Home/HomePage.tsx
+++ b/src/pages/Home/HomePage.tsx
@@ -1,5 +1,32 @@
+import { useShoesList } from "@/hooks/useShoes";
+import { Shoes } from "@/types/Shoes";
+
 function HomePage() {
-  return <div>HomePage</div>;
+  const { data: shoes = [], isLoading: isPending, error } = useShoesList();
+
+  if (isPending) return <p>Loading...</p>;
+  if (error) return <p>Error loading shoes data</p>;
+
+  console.log(shoes);
+
+  return (
+    <>
+      <section className="w-full h-[300px] bg-red-100">banner</section>
+      <div className="grid grid-cols-4 gap-4">
+        {shoes?.length > 0 ? (
+          shoes.map((shoe: Shoes) => (
+            <div className="shoe-item" key={shoe.id}>
+              {/* 이미지 대신 title과 completed 상태를 출력 */}
+              <h3>{shoe.title}</h3>
+              <p>{shoe.completed ? "Completed" : "Not Completed"}</p>
+            </div>
+          ))
+        ) : (
+          <p>No shoes available</p>
+        )}
+      </div>
+    </>
+  );
 }
 
 export default HomePage;

--- a/src/pages/Login/LoginPage.tsx
+++ b/src/pages/Login/LoginPage.tsx
@@ -57,7 +57,7 @@ function LoginPage() {
         />
         <button
           type="submit"
-          className="w-full py-2 px-4 mt- bg-blue-500 text-white font-semibold rounded-md hover:opacity-80"
+          className="w-full py-2 px-4 mt-4 bg-blue-500 text-white font-semibold rounded-md hover:opacity-80"
         >
           로그인
         </button>

--- a/src/pages/Login/LoginPage.tsx
+++ b/src/pages/Login/LoginPage.tsx
@@ -1,0 +1,78 @@
+import { login } from "@/apis/auth/auth.api";
+import Input from "@/components/Commons/Input/Input";
+import { useValidation } from "@/hooks/useValidation";
+import { useRef } from "react";
+import { useNavigate } from "react-router-dom";
+
+function LoginPage() {
+  const navigate = useNavigate();
+  const idRef = useRef<HTMLInputElement>(null);
+  const passwordRef = useRef<HTMLInputElement>(null);
+  const { errors, validateForm } = useValidation();
+
+  const handleLogin = (e: React.FormEvent) => {
+    e.preventDefault();
+
+    const id = idRef.current?.value.trim() || "";
+    const password = passwordRef.current?.value.trim() || "";
+
+    if (validateForm(id, password)) {
+      login({ id, password })
+        .then(() => {
+          alert("로그인 성공");
+          navigate("/");
+        })
+        .catch((error) => {
+          console.log("로그인 실패:", error);
+        });
+    }
+  };
+
+  const handleMoveSignUpPage = () => {
+    navigate("/sign-up");
+  };
+
+  return (
+    <section className="flex flex-col justify-center items-center h-[calc(100vh_-_52px)]">
+      <h2 className="text-2xl font-bold mb-12">로그인</h2>
+      <form
+        className="flex flex-col w-[310px] p-4 gap-6 sm:w-[450px] sm:gap-8"
+        onSubmit={handleLogin}
+      >
+        <Input
+          type="text"
+          name="id"
+          label="아이디"
+          ref={idRef}
+          placeholder="아이디를 입력하세요"
+          errorMessage={errors.idError}
+        />
+        <Input
+          type="password"
+          name="password"
+          label="패스워드"
+          ref={passwordRef}
+          placeholder="패스워드를 입력하세요"
+          errorMessage={errors.passwordError}
+        />
+        <button
+          type="submit"
+          className="w-full py-2 px-4 mt- bg-blue-500 text-white font-semibold rounded-md hover:opacity-80"
+        >
+          로그인
+        </button>
+      </form>
+      <p className="text-gray-500 text-center">
+        아직 회원이 아니신가요? <br />
+        <span
+          className="underline hover:text-black cursor-pointer"
+          onClick={handleMoveSignUpPage}
+        >
+          회원가입 하기
+        </span>
+      </p>
+    </section>
+  );
+}
+
+export default LoginPage;

--- a/src/pages/My/MyPage.tsx
+++ b/src/pages/My/MyPage.tsx
@@ -1,5 +1,78 @@
+import defaultAvatarImg from "@/assets/avatar-gray.svg";
+import Input from "@/components/Commons/Input/Input";
+import { useUpdateProfile, useUserInfos } from "@/hooks/useUser";
+import { useEffect, useRef } from "react";
+
 function MyPage() {
-  return <div>MyPage</div>;
+  // const navigate = useNavigate();
+  const { data: userInfos } = useUserInfos();
+  const { mutate, isPending } = useUpdateProfile();
+
+  const nicknameRef = useRef<HTMLInputElement>(null);
+  const avatarRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (nicknameRef.current && userInfos?.nickname) {
+      nicknameRef.current.value = userInfos.nickname;
+    }
+
+    if (avatarRef.current && userInfos?.avatarImg) {
+      avatarRef.current.value = userInfos.avatarImg;
+    }
+  }, [userInfos]);
+
+  const handleUpdateProfile = (e: React.FormEvent) => {
+    e.preventDefault();
+
+    const nickname = nicknameRef.current?.value || "";
+    const avatar = avatarRef.current?.files?.[0] || null;
+
+    const formData = new FormData();
+    formData.append("nickname", nickname);
+    if (avatar) {
+      formData.append("avatar", avatar);
+    }
+
+    mutate(formData);
+  };
+
+  return (
+    <section className="flex flex-col justify-center items-center h-[calc(100vh_-_52px)]">
+      <h2 className="text-2xl font-bold mb-6">My Page</h2>
+      <img
+        src={userInfos?.avatar || defaultAvatarImg}
+        alt="avatar"
+        className="w-24 h-24 mb-4 rounded-full border border-gray-200 object-cover"
+      />
+
+      <form
+        className="flex flex-col w-[310px] p-4 gap-6 sm:w-[450px] sm:gap-8"
+        onSubmit={handleUpdateProfile}
+      >
+        <Input
+          type="text"
+          name="nickname"
+          label="닉네임"
+          ref={nicknameRef}
+          placeholder="닉네임을 입력하세요"
+        />
+        <Input
+          type="file"
+          name="nickname"
+          label="프로필 이미지"
+          ref={avatarRef}
+        />
+
+        <button
+          type="submit"
+          className="w-full py-2 px-4 mt-4 bg-blue-500 text-white font-semibold rounded-md hover:opacity-80"
+          disabled={isPending}
+        >
+          프로필 변경
+        </button>
+      </form>
+    </section>
+  );
 }
 
 export default MyPage;

--- a/src/pages/SignUp/SignUpPage.tsx
+++ b/src/pages/SignUp/SignUpPage.tsx
@@ -1,0 +1,88 @@
+import { signUp } from "@/apis/auth/auth.api";
+import Input from "@/components/Commons/Input/Input";
+import { useValidation } from "@/hooks/useValidation";
+import { useRef } from "react";
+import { useNavigate } from "react-router-dom";
+
+function SignUpPage() {
+  const navigate = useNavigate();
+  const idRef = useRef<HTMLInputElement>(null);
+  const nickNameRef = useRef<HTMLInputElement>(null);
+  const passwordRef = useRef<HTMLInputElement>(null);
+  const { errors, validateForm } = useValidation();
+
+  const handleLogin = (e: React.FormEvent) => {
+    e.preventDefault();
+
+    const id = idRef.current?.value.trim() || "";
+    const password = passwordRef.current?.value.trim() || "";
+    const nickname = nickNameRef.current?.value.trim() || "";
+
+    if (validateForm(id, password, nickname)) {
+      signUp({ id, password, nickname })
+        .then(() => {
+          alert("회원가입 성공");
+          navigate("/login");
+        })
+        .catch((error) => {
+          console.log("회원가입 실패:", error);
+        });
+    }
+  };
+
+  const handleMoveLoginPage = () => {
+    navigate("/login");
+  };
+
+  return (
+    <section className="flex flex-col justify-center items-center h-[calc(100vh_-_52px)]">
+      <h2 className="text-2xl font-bold mb-12">회원가입</h2>
+      <form
+        className="flex flex-col w-[310px] p-4 gap-6 sm:w-[450px] sm:gap-8"
+        onSubmit={handleLogin}
+      >
+        <Input
+          type="text"
+          name="id"
+          label="아이디"
+          ref={idRef}
+          placeholder="아이디를 입력하세요"
+          errorMessage={errors.idError}
+        />
+        <Input
+          type="text"
+          name="id"
+          label="닉네임"
+          ref={nickNameRef}
+          placeholder="닉네임를 입력하세요"
+          errorMessage={errors.nicknameError}
+        />
+        <Input
+          type="password"
+          name="password"
+          label="패스워드"
+          ref={passwordRef}
+          placeholder="패스워드를 입력하세요"
+          errorMessage={errors.passwordError}
+        />
+        <button
+          type="submit"
+          className="w-full py-2 px-4 mt-4 bg-blue-500 text-white font-semibold rounded-md hover:opacity-80"
+        >
+          로그인
+        </button>
+      </form>
+      <p className="text-gray-500 text-center">
+        이미 회원이신가요? <br />
+        <span
+          className="underline hover:text-black cursor-pointer"
+          onClick={handleMoveLoginPage}
+        >
+          로그인 하러가기
+        </span>
+      </p>
+    </section>
+  );
+}
+
+export default SignUpPage;

--- a/src/routes/router.tsx
+++ b/src/routes/router.tsx
@@ -1,3 +1,5 @@
+import LoginPage from "@/pages/Login/LoginPage";
+import SignUpPage from "@/pages/SignUp/SignUpPage";
 import { createBrowserRouter } from "react-router-dom";
 import Layout from "../components/Layouts/Layout";
 import HomePage from "../pages/Home/HomePage";
@@ -10,6 +12,14 @@ const router = createBrowserRouter([
       {
         path: "/",
         element: <HomePage />,
+      },
+      {
+        path: "/login",
+        element: <LoginPage />,
+      },
+      {
+        path: "/sign-up",
+        element: <SignUpPage />,
       },
       {
         path: "/my-page",

--- a/src/types/Auth.ts
+++ b/src/types/Auth.ts
@@ -1,0 +1,8 @@
+export interface loginProps {
+  id: string;
+  password: string;
+}
+
+export interface signUpProps extends loginProps {
+  nickname: string;
+}

--- a/src/types/Shoes.ts
+++ b/src/types/Shoes.ts
@@ -1,0 +1,6 @@
+export type Shoes = {
+  userId: number;
+  id: number;
+  title: string;
+  completed: boolean;
+};

--- a/src/types/User.ts
+++ b/src/types/User.ts
@@ -1,0 +1,13 @@
+export interface UserProfileResponse {
+  avatar: string;
+  nickname: string;
+  message: string;
+  success: boolean;
+}
+
+export interface UpdateProfileType {
+  mutate: (formData: FormData) => void;
+  isPending: boolean;
+  isError: boolean;
+  error: Error | null;
+}

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -1,0 +1,13 @@
+export const validateId = (id: string) => {
+  return id.length >= 4;
+};
+
+export const validatePassword = (password: string) => {
+  const passwordRegex =
+    /^(?=.*[A-Z])(?=.*[!@#$%^&*])(?=.*[a-z0-9])[A-Za-z\d!@#$%^&*]{8,20}$/;
+  return passwordRegex.test(password);
+};
+
+export const validateNickname = (nickname: string) => {
+  return nickname.length >= 2;
+};

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -18,7 +18,12 @@
     "strict": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
-    "noFallthroughCasesInSwitch": true
+    "noFallthroughCasesInSwitch": true,
+
+    "baseUrl": "src",
+    "paths": {
+      "@/*": ["*"]
+    }
   },
   "include": ["src"]
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,7 +1,13 @@
-import { defineConfig } from 'vite'
-import react from '@vitejs/plugin-react'
+import react from "@vitejs/plugin-react";
+import path from "path";
+import { defineConfig } from "vite";
 
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react()],
-})
+  resolve: {
+    alias: {
+      "@": path.resolve(__dirname, "./src"), // '@'를 'src' 폴더로 매핑
+    },
+  },
+});


### PR DESCRIPTION
## 1. 로그인/회원가입 구현
 - 로그인, 회원가입 기능 구현
 - access token을 axios header에 붙여 유저 인증 정보 관리
 - access token은 local storage에 보관(refresh token이 있으면 해당 토큰을 cookie에 저장했을 것)
 - refresh token을 구현하지 않아 로그인 갱신은 되지 않는 상황(로그인 유효 시간: 30분 => access token 유효기간)

## 2. 마이페이지 구현
 - custom hook으로 프로필을 업데이트 하는 함수 구현. useMutation 사용하여 onSuccess와 onError로 분기 처리
<img src="https://github.com/user-attachments/assets/88afbacd-9cc7-4d95-b0fc-51d64ac6b613" height="500" />